### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ For most pixelized images Depix manages to find single-match results. It assumes
 
 After correct blocks have no more geometrical matches, it will output all correct blocks directly. For multi-match blocks, it outputs the average of all matches.
 
+## Reference Docs
+https://docs.contour.so/beurtschipper/Depix/getting-started
+
 ## Misc
 
 ### Usage issues


### PR DESCRIPTION
My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!