### PR TITLE
Add more comments and logging for better readability

### DIFF
--- a/depix.py
+++ b/depix.py
@@ -44,6 +44,8 @@ logging.info("%s rectangles left after moot filter" % len(pixelatedSubRectanges)
 
 rectangeSizeOccurences = findRectangleSizeOccurences(pixelatedSubRectanges)
 logging.info("Found %s different rectangle sizes" % len(rectangeSizeOccurences))
+if len(rectangeSizeOccurences) > max(10, pixelatedRectange.width * pixelatedRectange.height * 0.01):
+	logging.warning("Too many variants on block size. Re-pixelating the image might help.")
 
 logging.info("Finding matches in search image")
 rectangleMatches = findRectangleMatches(rectangeSizeOccurences, pixelatedSubRectanges, searchImage)

--- a/depixlib/functions.py
+++ b/depixlib/functions.py
@@ -1,6 +1,8 @@
 from depixlib.Rectangle import *
 from random import choice
 from PIL import Image
+import logging
+logging.basicConfig(level=logging.INFO)
 
 
 
@@ -93,6 +95,7 @@ def findRectangleSizeOccurences(colorRectanges):
 	return rectangeSizeOccurences
 
 
+# return a dictionary, with sub-rectangle coordinates as key and RectangleMatch as value
 def findRectangleMatches(rectangeSizeOccurences, pixelatedSubRectanges, searchImage):
 
 	rectangleMatches = {}
@@ -103,7 +106,9 @@ def findRectangleMatches(rectangeSizeOccurences, pixelatedSubRectanges, searchIm
 		rectangleWidth = rectangleSize[0]
 		rectangleHeight = rectangleSize[1]
 		pixelsInRectangle = rectangleWidth*rectangleHeight
+		# logging.info('For rectangle size {}x{}'.format(rectangleWidth, rectangleHeight))
 
+		# filter out the desired rectangle size
 		matchingRectangles = []
 		for colorRectange in pixelatedSubRectanges:
 
@@ -138,6 +143,9 @@ def findRectangleMatches(rectangeSizeOccurences, pixelatedSubRectanges, searchIm
 						newRectangleMatch = RectangleMatch(x, y, matchData)
 						rectangleMatches[(matchingRectangle.x,matchingRectangle.y)].append(newRectangleMatch)
 
+			# if x % 64 == 0:
+			# 	logging.info('Scanning in searchImage: {}/{}'.format(x, searchImage.width - rectangleWidth))
+
 	return rectangleMatches
 
 
@@ -159,7 +167,7 @@ def splitSingleMatchAndMultipleMatches(pixelatedSubRectanges, rectangleMatches):
 	for colorRectange in pixelatedSubRectanges:
 
 		firstMatchData = rectangleMatches[(colorRectange.x,colorRectange.y)][0].data
-		singleMatch = True
+		singleMatch = True   # only one data matches
 
 		for match in rectangleMatches[(colorRectange.x,colorRectange.y)]:
 


### PR DESCRIPTION
## Motivation

When reading the code, sometimes it's hard to know the data types or the meaning of variables. For example, what's the type of `rectangleMatches`? One would need to first go to `depix.py` and found that it was generated from `findRectangleMatches()`. After that, he or she knew it was of type `dict`, but what was the key and values?

Another motivation is that, when I tried out this tool the first time, the target image I used was inappropriate. Within that image, each 14x14 block was supposed to be of same color, but due to some lossy compression, each were instead composed of tiny little blocks as shown below:

![bad](https://user-images.githubusercontent.com/23246033/103944045-0fe74800-516e-11eb-9936-2f4a0196d6ae.png)

I got stuck on this screen for over an hour:

![stuck_for_over_an_hour](https://user-images.githubusercontent.com/23246033/103944893-4a051980-516f-11eb-89f3-1779da91a625.png)

Therefore, I think it would be better if the program could detect that **there was too many variants on block size**, which is what  I added in `depix.py` [line 47](https://github.com/beurtschipper/Depix/pull/44/files#diff-116e013900e1e21f95f055b37bd6307c8fdb4c7156380d489c17a6631ec70f6eR47). The additional logging feature in [line 109](https://github.com/beurtschipper/Depix/compare/main...davidhcefx:comment?expand=1#diff-bc914becd66b5b4ffa80b63ed19e1560ba27b2316d9b8c536b53489175dd858aR109) and [line 147](https://github.com/beurtschipper/Depix/compare/main...davidhcefx:comment?expand=1#diff-bc914becd66b5b4ffa80b63ed19e1560ba27b2316d9b8c536b53489175dd858aR147) were also for addressing this problem by including more verbosity.

Feel free to edit if you think it's too verbose or redundant.

