### PR TITLE
Made the README Bearable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
 # Depix
-
 Depix is a tool for recovering passwords from pixelized screenshots.
 
 This implementation works on pixelized images that were created with a linear box filter.
-
 In [this article](https://www.linkedin.com/pulse/recovering-passwords-from-pixelized-screenshots-sipke-mellema) I cover background information on pixelization and similar research.
 
 ## Example
-
-`python depix.py -p images/testimages/testimage3_pixels.png -s images/searchimages/debruinseq_notepad_Windows10_closeAndSpaced.png -o output.png`
-
 ![image](docs/img/Recovering_prototype_latest.png)
 
-## Usage
+## Installation
+* Clone the repo:
+```sh
+git clone https://github.com/beurtschipper/Depix.git
+cd Depix
+```
+* Install the dependencies:
+```sh
+python -m pip install -r requirements.txt
+```
+* Run Depix:
+```sh
+python depix.py -p /path/to/your/input/image.png -s images/searchimages/debruinseq_notepad_Windows10_closeAndSpaced.png -o /path/to/your/output.png
+```
+	* It is reccomended that you use a folder in the `images/searchimages/` directory for the `-s` flag in order to achieve best results.
+	* `-p` and `-o` (Input and output, respectively) can be either relative paths (to the repo's folder) or absolute to your drive. (`/` or `C:\`)
 
+## About
+### Making a Search Image
 * Cut out the pixelated blocks from the screenshot as a single rectangle.
-* Paste a [De Bruijn sequence](https://damip.net/article-de-bruijn-sequence) with expected characters in an editor with the same font settings (text size, font, color, hsl).
-* Make a screenshot of the sequence. If possible, use the same screenshot tool that was used to create the pixelized image.
-* Run `python depix.py -p [pixelated rectangle image] -s [search sequence image] -o output.png`
+* Paste a [De Bruijn sequence](https://en.wikipedia.org/wiki/De_Bruijn_sequence) with expected characters in an editor with the same font settings as your input image (Same text size, similar font, same colors).
+* Make a screenshot of the sequence.
+* Move that screenshot into a folder like `images/searchimages/`.
+* Run Depix with the `-s` flag set to the location of this screenshot.
 
-## Algorithm
-
+### Algorithm
 The algorithm uses the fact that the linear box filter processes every block separately. For every block it pixelizes all blocks in the search image to check for direct matches.
 
 For most pixelized images Depix manages to find single-match results. It assumes these are correct. The matches of surrounding multi-match blocks are then compared to be geometrically at the same distance as in the pixelized image. Matches are also treated as correct. This process is repeated a couple of times.
 
 After correct blocks have no more geometrical matches, it will output all correct blocks directly. For multi-match blocks, it outputs the average of all matches.
-
-## Misc
-
-### Usage issues
-
-* **Dependency Issues** See: https://github.com/beurtschipper/Depix/issues/12
-* 
+gorithm uses the fact that the linear box filter processes every block separately. For every block it pixelizes all blocks in the search image to check for direct matches. 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The algorithm uses the fact that the linear box filter processes every block sep
 For most pixelized images Depix manages to find single-match results. It assumes these are correct. The matches of surrounding multi-match blocks are then compared to be geometrically at the same distance as in the pixelized image. Matches are also treated as correct. This process is repeated a couple of times.
 
 After correct blocks have no more geometrical matches, it will output all correct blocks directly. For multi-match blocks, it outputs the average of all matches.
-gorithm uses the fact that the linear box filter processes every block separately. For every block it pixelizes all blocks in the search image to check for direct matches. 
+The algorithm uses the fact that the linear box filter processes every block separately. For every block it pixelizes all blocks in the search image to check for direct matches. 


### PR DESCRIPTION
This project \[unfortunately\] has a pretty terrible README for newcomers.

At first, _I_ didn't know how to use this. I hadn't a clue on what to put for the `-s` flag. Literal guesswork lead me to some form of a result. :(

## What I've Done
* Fixed random spacing issues with paragraphs.
* Added a coherent installation and usage guide.
* Organised miscellaneous paragraphs which all seemed to fit nicely in an _About_ section.
* Changed the link about De Bruijn sequences to one from Wikipedia, for a more credible and detailed description of what a De Bruijn sequence _is_.
* Upgraded understandability and overall quality of how to create your own search image, this helps for newcomers to understand how the magic of Depix works. ;)
* Removed the part on the so-called "dependency issue". It's nothing. You didn't tell people to run `pip install -r requirements.txt` for your project. Python can't run code without it's dependencies. I also added the fix to the _Installation_ section of the README.

Thanks to open source, Depix will be better than ever!