### PR TITLE
README.md: describe limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ The algorithm uses the fact that the linear box filter processes every block sep
 ### Known limitations
 
 * The algorithm currently performs pixel averaging in the image's gamma-corrected RGB space. As a result, it cannot reconstruct images pixelated using linear RGB.
-* The algorithm matches by integer block-boundaries. As a result, it has the underlying assumption that all characters rendered (both in the de Brujin sequence and the pixelated image) that text positioning is done at pixel level. However, some modern text rasterizers position text [at sub-pixel accuracies](http://agg.sourceforge.net/antigrain.com/research/font_rasterization/).
+* The algorithm matches by integer block-boundaries. As a result, it has the underlying assumption that for all characters rendered (both in the de Brujin sequence and the pixelated image), the text positioning is done at pixel level. However, some modern text rasterizers position text [at sub-pixel accuracies](http://agg.sourceforge.net/antigrain.com/research/font_rasterization/).

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ For most pixelized images Depix manages to find single-match results. It assumes
 
 After correct blocks have no more geometrical matches, it will output all correct blocks directly. For multi-match blocks, it outputs the average of all matches.
 The algorithm uses the fact that the linear box filter processes every block separately. For every block it pixelizes all blocks in the search image to check for direct matches. 
+
+### Known limitations
+
+* The algorithm currently performs pixel averaging in the image's gamma-corrected RGB space. As a result, it cannot reconstruct images pixelated using linear RGB.
+* The algorithm matches by integer block-boundaries. As a result, it has the underlying assumption that all characters rendered (both in the de Brujin sequence and the pixelated image) that text positioning is done at pixel level. However, some modern text rasterizers position text [at sub-pixel accuracies](http://agg.sourceforge.net/antigrain.com/research/font_rasterization/).


### PR DESCRIPTION
Add a section to describe common failure modes of the algorithm. Problem (1) is explored in genpixed.py, and it shouldn't be too hard to fix with an additional pixlating-mode switch. Problem (2) is much harder.

(Of course, this doesn't mean taking screenshots on a mac makes stuff safer.)