### PR TITLE
README Text is set to Block Code Unintentionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ python -m pip install -r requirements.txt
 ```sh
 python depix.py -p /path/to/your/input/image.png -s images/searchimages/debruinseq_notepad_Windows10_closeAndSpaced.png -o /path/to/your/output.png
 ```
-	* It is reccomended that you use a folder in the `images/searchimages/` directory for the `-s` flag in order to achieve best results.
-	* `-p` and `-o` (Input and output, respectively) can be either relative paths (to the repo's folder) or absolute to your drive. (`/` or `C:\`)
+* It is reccomended that you use a folder in the `images/searchimages/` directory for the `-s` flag in order to achieve best results.
+* `-p` and `-o` (Input and output, respectively) can be either relative paths (to the repo's folder) or absolute to your drive. (`/` or `C:\`)
 
 ## Example usage
 


### PR DESCRIPTION
Two lines of the README are indented, which makes GitHub think it's some code that is embedded.
I removed the indent, which restores the text back to the dot points that they are. ;)