### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/depixlib/functions.py
+++ b/depixlib/functions.py
@@ -186,7 +186,7 @@ def findRectangleMatches(
                         matchData.append(newPixel)
 
                         if averageType == "gammacorrected":
-                            rr, gg, rr = newPixel
+                            rr, gg, bb = newPixel
 
                         if averageType == "linear":
                             newPixelLinear = tuple(


### PR DESCRIPTION
When running `depix` with gamma correction on any image, you would get `UnboundLocalError: local variable 'bb' referenced before assignment`. This is caused by a typo when assigning colour component variables to pixels as the blue component (`bb`) is never assigned a value before it is used.